### PR TITLE
Add Dockerfile and CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,68 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@2.2.0
+
+jobs:
+  build_docker:
+    environment:
+      TZ: "/usr/share/zoneinfo/America/New_York"
+      SCRATCH: "/scratch"
+    docker:
+      - image: docker:18.06.1-ce-git
+    working_directory: /tmp/src/DSI-Studio
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          no_output_timeout: 3h
+          command: |
+            # Build docker image
+            e=1 && for i in {1..5}; do
+              docker build \
+                --rm=false \
+                -t pennbbl/dsistudio:latest
+              && e=0 && break || sleep 15
+            done && [ "$e" -eq "0" ]
+
+  build_windows:
+    executor:
+      name: win/default
+    steps:
+      # This needs to be replaced with the windows build
+      - run:
+         command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
+         shell: powershell.exe
+      - run:
+         command: echo hello && echo world
+         shell: bash.exe
+      - run:
+         command: echo hello & echo world
+         shell: cmd.exe
+
+  deployable:
+    docker:
+      - image: busybox:latest
+    steps:
+      - run: echo Deployable!
+
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build_linux:
+          filters:
+            tags:
+              only: /.*/
+
+      - deployable:
+          requires:
+            - build_docker
+            - build_windows
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# Use Ubuntu 16.04 LTS
+FROM ubuntu:16.04
+
+# Prepare environment
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+                    curl \
+                    ca-certificates \
+                    xvfb \
+                    build-essential \
+                    autoconf \
+                    libtool \
+                    pkg-config \
+                    libfontconfig1 \
+                    libfreetype6 \
+                    libgl1-mesa-dev \
+                    libglu1-mesa-dev \
+                    libgomp1 \
+                    libice6 \
+                    libxcursor1 \
+                    libxft2 \
+                    libxinerama1 \
+                    libxrandr2 \
+                    libxrender1 \
+                    libxt6 \
+                    wget \
+                    libboost-all-dev \
+                    zlib1g \
+                    zlib1g-dev \
+                    unzip \
+                    libgl1-mesa-dev \
+                    libglu1-mesa-dev \
+                    freeglut3-dev \
+                    mesa-utils \
+                    g++ \
+                    gcc \
+                    make \
+                    zlib1g-dev \
+                    git \
+                    software-properties-common && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Get newer qt5
+RUN add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial \
+    && apt-get update \
+    && apt install -y --no-install-recommends \
+    freetds-common libclang1-5.0 libllvm5.0 libodbc1 libsdl2-2.0-0 libsndio6.1 \
+    libsybdb5 libxcb-xinerama0 qt5123d qt512base qt512canvas3d \
+    qt512connectivity qt512declarative qt512graphicaleffects \
+    qt512imageformats qt512location qt512multimedia qt512scxml qt512svg \
+    qt512wayland qt512x11extras qt512xmlpatterns qt512charts-no-lgpl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+# Install DSI Studio
+ENV QT_BASE_DIR="/opt/qt512"
+ENV QTDIR="$QT_BASE_DIR" \
+    PATH="$QT_BASE_DIR/bin:$PATH:/opt/dsi-studio/dsi_studio_64" \
+    LD_LIBRARY_PATH="$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH" \
+    PKG_CONFIG_PATH="$QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH"
+RUN mkdir /opt/dsi-studio \
+  && cd /opt/dsi-studio \
+  && git clone https://github.com/frankyeh/DSI-Studio.git \
+  && mv DSI-Studio src \
+  && git clone https://github.com/frankyeh/TIPL.git \
+  && mv TIPL src/tipl \
+  && mkdir build && cd build \
+  && /opt/qt512/bin/qmake ../src && make \
+  && cd /opt/dsi-studio \
+  && curl -sSLO 'https://upenn.box.com/shared/static/01r73d4a15utl13himv4d7cjpa6etf6z.gz' \
+  && tar xvfz 01r73d4a15utl13himv4d7cjpa6etf6z.gz \
+  && rm 01r73d4a15utl13himv4d7cjpa6etf6z.gz \
+  && cd dsi_studio_64 \
+  && mv ../build/dsi_studio . \
+  && rm -rf /opt/dsi-studio/src /opt/dsi-studio/build


### PR DESCRIPTION
This PR adds a Dockerfile and initial CircleCI setup. It's possible to do a Windows build for free on CircleCI too - I added their "hello world" on a windows executor that can be replaced with your build script. Once we get the builds working we can set up jobs that deploy the built packages