### PR TITLE
Add Docker containers to build master

### DIFF
--- a/build_packages/ubuntu_1804_master/Dockerfile
+++ b/build_packages/ubuntu_1804_master/Dockerfile
@@ -1,0 +1,73 @@
+FROM ubuntu:18.04 as builder-stage
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Prepare environment
+# We use a ppa for the qt because 18.04 is tool old for DSI
+RUN apt update && apt full-upgrade -y && \
+  apt install --no-install-recommends -y software-properties-common && \
+  add-apt-repository -y ppa:beineri/opt-qt-5.12.8-bionic && \
+  add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+  apt install -y --no-install-recommends \
+  unzip \
+  curl \
+  make \
+  git \
+  libboost-all-dev \
+  zlib1g-dev \
+  ca-certificates \
+  qt512base \
+  qt512charts-no-lgpl \
+  mesa-common-dev \
+  libglu1-mesa-dev \
+  gcc-9 \
+  g++-9 && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 \
+                    99 \
+                    --slave   /usr/bin/cc cc /usr/bin/gcc-9 \
+                    --slave   /usr/bin/c++ c++ /usr/bin/g++-9 \
+                    --slave   /usr/bin/g++ g++ /usr/bin/g++-9 \
+                    --slave   /usr/bin/gcov gcov /usr/bin/gcov-9 \
+                    --slave   /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-9 \
+                    --slave   /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-9 \
+                    --slave   /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-9 \
+                    --slave   /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-9 \
+                    --slave   /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-9
+
+RUN update-alternatives --auto gcc
+
+#Need to use a different shell so the QT ENV script works
+SHELL ["/bin/bash", "-c"]
+
+#We clone here the specific 2021_06 version, and the closest TIPL commit
+RUN source /opt/qt512/bin/qt512-env.sh \
+  && mkdir /opt/dsi-studio \
+  && cd /opt/dsi-studio \
+  && git clone https://github.com/frankyeh/DSI-Studio.git \
+  && mv DSI-Studio src \
+  && git clone https://github.com/frankyeh/TIPL.git \
+  && mv TIPL src/tipl \
+  && mkdir -p /opt/dsi-studio/build \
+  && cd /opt/dsi-studio/build \
+  && qmake ../src/dsi_studio.pro \
+  && make -k -j$(nproc) \
+  && cd /opt/dsi-studio \
+  && curl -sSLO 'https://www.dropbox.com/s/xha3srev45at7vx/dsi_studio_64.zip' \
+  && unzip dsi_studio_64.zip \
+  && rm dsi_studio_64.zip \
+  && cd dsi_studio_64 \
+  && rm *.dll \
+  && rm *.exe \
+  && rm -rf iconengines \
+  && rm -rf imageformats \
+  && rm -rf platforms \
+  && rm -rf styles \
+  && mv ../build/dsi_studio . \
+  && rm -rf /opt/dsi-studio/src /opt/dsi-studio/build
+
+#Create an empty container and transfer only the compiled software out
+FROM scratch
+COPY --from=builder-stage /opt/dsi-studio/dsi_studio_64 /

--- a/build_packages/ubuntu_1804_master/README.md
+++ b/build_packages/ubuntu_1804_master/README.md
@@ -1,0 +1,12 @@
+# Building packages for Ubuntu 18.04
+
+Use build.sh to build package in a clean Ubuntu Bionic 18.04 environment.
+
+Generates  dsi_studio_ubuntu_18.04.zip
+
+# Dependencies for installation
+Requires `add-apt-repository -y ppa:beineri/opt-qt-5.12.8-bionic` on client system
+and `sudo apt install qt512base qt512charts-no-lgpl`
+
+# Installation
+Unzip file and run `./dsi_studio`

--- a/build_packages/ubuntu_1804_master/build.sh
+++ b/build_packages/ubuntu_1804_master/build.sh
@@ -1,0 +1,3 @@
+#Use the new docker buildkit, which allows us to copy files out after completion
+DOCKER_BUILDKIT=1 docker build -o dsi_studio .
+zip -r dsi_studio_ubuntu_18.04.zip dsi_studio

--- a/build_packages/ubuntu_2004_master/Dockerfile
+++ b/build_packages/ubuntu_2004_master/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:20.04 as builder-stage
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Prepare environment
+RUN apt update && apt full-upgrade -y && \
+  apt install -y --no-install-recommends \
+  unzip \
+  curl \
+  make \
+  git \
+  libboost-all-dev \
+  zlib1g-dev \
+  ca-certificates \
+  qt5-qmake \
+  qt5-default \
+  libqt5charts5-dev \
+  libqt5opengl5-dev \
+  gcc \
+  g++ && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+#We clone here the specific 2021_06 version, and the closest TIPL commit
+RUN mkdir /opt/dsi-studio \
+  && cd /opt/dsi-studio \
+  && git clone https://github.com/frankyeh/DSI-Studio.git \
+  && mv DSI-Studio src \
+  && git clone https://github.com/frankyeh/TIPL.git \
+  && mv TIPL src/tipl \
+  && mkdir -p /opt/dsi-studio/build \
+  && cd /opt/dsi-studio/build \
+  && qmake ../src/dsi_studio.pro \
+  && make -k -j$(nproc) \
+  && cd /opt/dsi-studio \
+  && curl -sSLO 'https://www.dropbox.com/s/xha3srev45at7vx/dsi_studio_64.zip' \
+  && unzip dsi_studio_64.zip \
+  && rm dsi_studio_64.zip \
+  && cd dsi_studio_64 \
+  && rm *.dll \
+  && rm *.exe \
+  && rm -rf iconengines \
+  && rm -rf imageformats \
+  && rm -rf platforms \
+  && rm -rf styles \
+  && mv ../build/dsi_studio . \
+  && rm -rf /opt/dsi-studio/src /opt/dsi-studio/build
+
+#Create an empty container and transfer only the compiled software out
+FROM scratch
+COPY --from=builder-stage /opt/dsi-studio/dsi_studio_64 /

--- a/build_packages/ubuntu_2004_master/README.md
+++ b/build_packages/ubuntu_2004_master/README.md
@@ -1,0 +1,14 @@
+# Building packages for Ubuntu 20.04
+
+Use build.sh to build package in a clean Ubuntu Bionic 20.04 environment.
+
+Generates  dsi_studio_ubuntu_20.04.zip
+
+# Dependencies for installation
+
+```sh
+$ sudo apt install libqt5charts5 libqt5opengl5
+```
+
+# Installation
+Unzip file and run `./dsi_studio`

--- a/build_packages/ubuntu_2004_master/build.sh
+++ b/build_packages/ubuntu_2004_master/build.sh
@@ -1,0 +1,3 @@
+#Use the new docker buildkit, which allows us to copy files out after completion
+DOCKER_BUILDKIT=1 docker build -o dsi_studio .
+zip -r dsi_studio_ubuntu_20.04.zip dsi_studio


### PR DESCRIPTION
Followup on #64

These containers build master as of *right now*.

You can use these to ensure a clean build environment can build the code.

Next time you tag a new release, you can copy these to the release directory and and re-add the specific tag checkout for building a release version. (i.e. `git clone --branch <TAGNAME>`)