### PR TITLE
Change permission of dsi_studio

### DIFF
--- a/build_packages/ubuntu_2004/Dockerfile
+++ b/build_packages/ubuntu_2004/Dockerfile
@@ -45,6 +45,7 @@ RUN mkdir /opt/dsi-studio \
   && rm -rf platforms \
   && rm -rf styles \
   && mv ../build/dsi_studio . \
+  && chmod 755 dsi_studio \
   && rm -rf /opt/dsi-studio/src /opt/dsi-studio/build
 
 #Create an empty container and transfer only the compiled software out


### PR DESCRIPTION
The current Dockerfile generates dsi_studio with 666. chmod 755 is necessary to make it executable.