### PR TITLE
Ensure variant_image copies all attributes

### DIFF
--- a/cmd/img.hpp
+++ b/cmd/img.hpp
@@ -32,9 +32,12 @@ private:
         I_int8 = rhs.I_int8;
         pixel_type = decltype(pixel_type)(rhs.pixel_type);
         shape = rhs.shape;
+        dim4 = rhs.dim4;
         is_mni = rhs.is_mni;
+        interpolation = rhs.interpolation;
         vs = rhs.vs;
         T = rhs.T;
+        error_msg = rhs.error_msg;
     }
 public:
     template<typename Fun, typename Arg>


### PR DESCRIPTION
## Summary
- Preserve additional state in `variant_image` copy constructor, including 4D dimensions, interpolation flag, and error message

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eca28d4f4832ba406c79536cee1f5