### PR TITLE
[codex] Fix QC total scan count

### DIFF
--- a/cmd/qc.cpp
+++ b/cmd/qc.cpp
@@ -115,7 +115,7 @@ std::string quality_check_fib_files(const std::vector<std::filesystem::path>& fi
         else
             out << std::endl;
     }
-    out << "total scans: " << output.size() << std::endl;
+    out << "total scans: " << file_list.size() << std::endl;
     return out.str();
 }
 


### PR DESCRIPTION
## Summary
- Report the number of FIB files checked instead of the size of an unused output vector.
- Fixes FIB QC summaries always printing total scans as 0.

## Validation
- Reviewed the isolated diff.
- Ran git diff --check for the staged change.