### PR TITLE
Fix empty density map trimming

### DIFF
--- a/libs/tracking/tract_model.cpp
+++ b/libs/tracking/tract_model.cpp
@@ -2482,7 +2482,7 @@ void TractModel::get_density_map(tipl::image<3,unsigned int>& mapping,
             ++m[pos];
     });
 
-    while(maps.back().empty() && !maps.empty())
+    while(!maps.empty() && maps.back().empty())
         maps.pop_back();
 
     tipl::par_for(s.size(),[&](unsigned int i)


### PR DESCRIPTION
## Summary
- check that the density-map vector is non-empty before reading maps.back()
- avoid an out-of-bounds access when no per-thread density maps were populated

## Testing
- git diff --check